### PR TITLE
Add Jira Ticket Analysis with API and React UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,37 @@ Run tests with pytest:
 ```bash
 pytest
 ```
+
+## Jira Story Ticket Count
+
+### Backend API
+
+Install dependencies:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+Set environment variables:
+
+```bash
+export JIRA_URL=https://your-domain.atlassian.net
+export JIRA_USERNAME=your_email@example.com
+export JIRA_TOKEN=your_api_token
+```
+
+Start the API server:
+
+```bash
+uvicorn backend.app:app --reload --host 0.0.0.0 --port 8000
+```
+
+Use the API:
+
+```bash
+curl "http://127.0.0.1:8000/stories/tickets/count?project=PROJECTKEY"
+```
+
+### React UI
+
+Open `frontend/index.html` in your browser (the UI will fetch data from `http://localhost:8000` by default).

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,2 @@
+# Backend package initializer
+"""JIRA Story Ticket Count backend package."""

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,25 @@
+"""
+FastAPI application exposing JIRA story ticket count endpoint.
+"""
+from fastapi import FastAPI, HTTPException, Query
+from typing import Dict
+
+from .jira_service import get_ticket_counts_by_story
+
+app = FastAPI(title="JIRA Story Ticket Count API")
+
+
+@app.get("/stories/tickets/count", response_model=Dict[str, int])
+def story_ticket_counts(
+    project: str = Query(..., description="JIRA project key, e.g., 'TEST'")
+) -> Dict[str, int]:
+    """
+    Endpoint to retrieve the number of subtasks broken down per Story issue.
+
+    :param project: JIRA project key (string).
+    :return: JSON mapping story keys to subtask counts.
+    """
+    try:
+        return get_ticket_counts_by_story(project)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,17 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """
+    Application settings and environment variables for JIRA connectivity.
+    """
+    JIRA_URL: str
+    JIRA_USERNAME: str
+    JIRA_TOKEN: str
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()

--- a/backend/jira_service.py
+++ b/backend/jira_service.py
@@ -1,0 +1,37 @@
+"""
+Service layer to interact with JIRA API and aggregate ticket counts per story.
+"""
+import requests
+from typing import Dict
+
+from .config import settings
+
+
+def get_ticket_counts_by_story(project_key: str) -> Dict[str, int]:
+    """
+    Fetches all Story issues for a given JIRA project and returns a mapping
+    of story key to its number of subtasks.
+
+    :param project_key: JIRA project key (e.g., "TEST").
+    :return: dict where keys are story issue keys and values are subtask counts.
+    """
+    url = f"{settings.JIRA_URL}/rest/api/2/search"
+    jql = f"project = {project_key} AND issuetype = Story"
+    params = {
+        "jql": jql,
+        "fields": "subtasks",
+        "maxResults": 1000,
+    }
+    response = requests.get(
+        url,
+        auth=(settings.JIRA_USERNAME, settings.JIRA_TOKEN),
+        params=params,
+    )
+    response.raise_for_status()
+    data = response.json()
+    counts: Dict[str, int] = {}
+    for issue in data.get("issues", []):
+        key = issue.get("key")
+        subtasks = issue.get("fields", {}).get("subtasks", []) or []
+        counts[key] = len(subtasks)
+    return counts

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+pydantic

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>JIRA Story Ticket Count</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+    th, td { border: 1px solid #ddd; padding: 8px; }
+    th { background-color: #f2f2f2; }
+    canvas { max-width: 600px; margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <h1>JIRA Story Ticket Count</h1>
+  <div id="root"></div>
+  <script type="text/javascript">
+    const { useState, useEffect, useRef } = React;
+
+    function App() {
+      const [project, setProject] = useState('');
+      const [data, setData] = useState({});
+      const chartRef = useRef(null);
+
+      useEffect(() => {
+        if (data && chartRef.current) {
+          const ctx = chartRef.current.getContext('2d');
+          new Chart(ctx, {
+            type: 'bar',
+            data: {
+              labels: Object.keys(data),
+              datasets: [{
+                label: 'Sub-task Count',
+                data: Object.values(data),
+                backgroundColor: 'rgba(75, 192, 192, 0.6)'
+              }]
+            },
+            options: {
+              responsive: true,
+              scales: { y: { beginAtZero: true } }
+            }
+          });
+        }
+      }, [data]);
+
+      const fetchData = () => {
+        fetch(`http://localhost:8000/stories/tickets/count?project=${encodeURIComponent(project)}`)
+          .then(res => res.json())
+          .then(setData)
+          .catch(console.error);
+      };
+
+      return (
+        React.createElement('div', null,
+          React.createElement('input', {
+            type: 'text',
+            placeholder: 'Project Key (e.g., TEST)',
+            value: project,
+            onChange: e => setProject(e.target.value)
+          }),
+          React.createElement('button', { onClick: fetchData }, 'Fetch'),
+          Object.keys(data).length > 0 && React.createElement('table', null,
+            React.createElement('thead', null,
+              React.createElement('tr', null,
+                React.createElement('th', null, 'Story'),
+                React.createElement('th', null, 'Sub-task Count')
+              )
+            ),
+            React.createElement('tbody', null,
+              Object.entries(data).map(([key, count]) =>
+                React.createElement('tr', { key },
+                  React.createElement('td', null, key),
+                  React.createElement('td', null, count)
+                )
+              )
+            )
+          ),
+          Object.keys(data).length > 0 && React.createElement('canvas', { ref: chartRef })
+        )
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(
+      React.createElement(App)
+    );
+  </script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,25 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.app as app_module
+
+# Replace actual service call with a fake implementation for testing
+@pytest.fixture(autouse=True)
+def patch_jira_service(monkeypatch):
+    def fake_get_ticket_counts(project_key):
+        return {"TEST-1": 2, "TEST-2": 0}
+
+    monkeypatch.setattr(app_module, "get_ticket_counts_by_story", fake_get_ticket_counts)
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)
+
+def test_story_ticket_counts_success(client):
+    response = client.get("/stories/tickets/count?project=TEST")
+    assert response.status_code == 200
+    assert response.json() == {"TEST-1": 2, "TEST-2": 0}
+
+def test_story_ticket_counts_missing_project(client):
+    response = client.get("/stories/tickets/count")
+    assert response.status_code == 422  # validation error for missing required query param

--- a/tests/test_jira_service.py
+++ b/tests/test_jira_service.py
@@ -1,0 +1,33 @@
+import pytest
+
+from backend.jira_service import get_ticket_counts_by_story
+
+
+class DummyResponse:
+    def __init__(self, json_data, status_code=200):
+        self._json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+def test_get_ticket_counts_by_story(monkeypatch):
+    dummy_issues = {
+        "issues": [
+            {"key": "TEST-1", "fields": {"subtasks": [{"id": "1"}, {"id": "2"}]}},
+            {"key": "TEST-2", "fields": {"subtasks": []}},
+        ]
+    }
+
+    def fake_get(url, auth, params):
+        assert "jql" in params
+        return DummyResponse(dummy_issues)
+
+    monkeypatch.setattr("backend.jira_service.requests.get", fake_get)
+    counts = get_ticket_counts_by_story("TEST")
+    assert counts == {"TEST-1": 2, "TEST-2": 0}


### PR DESCRIPTION
This pull request includes a Python program to find the number of Jira tickets broken by stories, along with unit tests. The program is exposed as an API in a standard way. Additionally, a UI with tables and graphs is generated in React, without unit tests.