### PR TITLE
Add Jira Ticket Analysis with API and React UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,41 @@ Example response:
 
 ## Testing
 
-Run tests with pytest:
+Run tests with pytest (install pytest if not already installed):
 
 ```bash
+pip install pytest
 pytest
 ```
+
+## Jira Tickets Analysis
+
+### Python API
+
+Install additional dependencies:
+
+```bash
+pip install requests
+```
+
+Fetch ticket counts grouped by story:
+
+```bash
+curl "http://127.0.0.1:8000/jira/tickets_by_story?jira_url=https://your-domain.atlassian.net&jql=project=PROJ&username=you@example.com&api_token=API_TOKEN"
+```
+
+Example response:
+
+```json
+{"STORY-1": 5, "STORY-2": 3}
+```
+
+### React UI
+
+A static React-based UI is available under the `/ui` path. Open your browser at:
+
+```
+http://127.0.0.1:8000/ui/index.html
+```
+
+It provides inputs for JIRA credentials and JQL, and displays a table and bar chart of ticket counts by story.

--- a/jira_counter.py
+++ b/jira_counter.py
@@ -1,0 +1,48 @@
+"""
+Module for fetching Jira issues and counting tickets broken down by stories.
+"""
+from typing import Any, Dict, List, Tuple
+import requests
+
+
+def count_tickets_by_story(issues: List[Dict[str, Any]]) -> Dict[str, int]:
+    """
+    Count number of tickets grouped by their parent story key.
+
+    Args:
+        issues: list of issue dicts, each containing either a 'story_key' or JIRA API 'fields.parent.key'.
+
+    Returns:
+        Mapping of story key to count of tickets.
+    """
+    counts: Dict[str, int] = {}
+    for issue in issues:
+        # Extract story key from JIRA API structure or direct field
+        if 'fields' in issue and issue['fields'].get('parent'):
+            story_key = issue['fields']['parent']['key']
+        else:
+            story_key = issue.get('story_key')
+        if not story_key:
+            continue
+        counts[story_key] = counts.get(story_key, 0) + 1
+    return counts
+
+
+def fetch_issues_by_jql(jira_url: str, jql: str, auth: Tuple[str, str]) -> List[Dict[str, Any]]:
+    """
+    Fetch issues from JIRA using REST API search endpoint.
+
+    Args:
+        jira_url: Base URL of JIRA instance (e.g. https://your-domain.atlassian.net)
+        jql: JQL query string to filter issues.
+        auth: Tuple of (username, api_token) for basic authentication.
+
+    Returns:
+        List of issue dictionaries from JIRA API response.
+    """
+    search_url = f"{jira_url.rstrip('/')}" + "/rest/api/2/search"
+    params = {'jql': jql, 'maxResults': 1000}
+    response = requests.get(search_url, params=params, auth=auth)
+    response.raise_for_status()
+    data = response.json()
+    return data.get('issues', [])

--- a/main.py
+++ b/main.py
@@ -1,7 +1,12 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
 from calculator import add, subtract, multiply, divide
+from jira_counter import count_tickets_by_story, fetch_issues_by_jql
 
 app = FastAPI()
+
+# Mount static files for the React-based UI
+app.mount("/ui", StaticFiles(directory="ui", html=True), name="ui")
 
 @app.get("/calculate")
 def calculate(operation: str, x: float, y: float):
@@ -19,3 +24,14 @@ def calculate(operation: str, x: float, y: float):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return {"operation": operation, "x": x, "y": y, "result": result}
+
+
+@app.get("/jira/tickets_by_story")
+def tickets_by_story(jira_url: str, jql: str, username: str, api_token: str):
+    """
+    Fetch issues from JIRA matching JQL and return ticket counts grouped by story.
+    """
+    auth = (username, api_token)
+    issues = fetch_issues_by_jql(jira_url, jql, auth)
+    counts = count_tickets_by_story(issues)
+    return counts

--- a/tests/test_jira_counter.py
+++ b/tests/test_jira_counter.py
@@ -1,0 +1,52 @@
+import requests
+import pytest
+
+from jira_counter import count_tickets_by_story, fetch_issues_by_jql
+
+
+def test_count_tickets_by_story_simple():
+    issues = [
+        {'story_key': 'STORY-1'},
+        {'story_key': 'STORY-2'},
+        {'story_key': 'STORY-1'},
+    ]
+    counts = count_tickets_by_story(issues)
+    assert counts == {'STORY-1': 2, 'STORY-2': 1}
+
+
+def test_count_tickets_by_story_jira_structure():
+    issues = [
+        {'fields': {'parent': {'key': 'STORY-3'}}},
+        {'fields': {'parent': {'key': 'STORY-3'}}},
+    ]
+    counts = count_tickets_by_story(issues)
+    assert counts == {'STORY-3': 2}
+
+
+class DummyResponse:
+    def __init__(self, json_data, status_code=200):
+        self._json = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise requests.HTTPError(f"Status code: {self.status_code}")
+
+
+def test_fetch_issues_by_jql(monkeypatch):
+    jira_url = "https://example.atlassian.net"
+    jql = "project=TEST"
+    auth = ("user", "token")
+    expected_issues = [{'fields': {'parent': {'key': 'STORY-4'}}}]
+
+    def mock_get(url, params, auth=None):
+        assert url == f"{jira_url}/rest/api/2/search"
+        assert params['jql'] == jql
+        return DummyResponse({'issues': expected_issues})
+
+    monkeypatch.setattr(requests, 'get', mock_get)
+    issues = fetch_issues_by_jql(jira_url, jql, auth)
+    assert issues == expected_issues

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Jira Tickets By Story</title>
+  <script src="https://unpkg.com/react/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script>
+    const { useState } = React;
+    const {
+      BarChart,
+      Bar,
+      XAxis,
+      YAxis,
+      CartesianGrid,
+      Tooltip,
+      ResponsiveContainer
+    } = Recharts;
+
+    function App() {
+      const [data, setData] = useState({});
+      const [jiraUrl, setJiraUrl] = useState('');
+      const [jql, setJql] = useState('');
+      const [username, setUsername] = useState('');
+      const [apiToken, setApiToken] = useState('');
+
+      const fetchData = () => {
+        axios.get('/jira/tickets_by_story', {
+          params: { jira_url: jiraUrl, jql, username, api_token: apiToken }
+        })
+        .then(res => setData(res.data))
+        .catch(console.error);
+      };
+
+      const rows = Object.entries(data).map(([story, count]) => ({ story, count }));
+
+      return (
+        React.createElement('div', null,
+          React.createElement('h1', null, 'Jira Tickets By Story'),
+          React.createElement('div', null,
+            React.createElement('input', { placeholder: 'Jira URL', value: jiraUrl, onChange: e => setJiraUrl(e.target.value) }),
+            React.createElement('input', { placeholder: 'JQL', value: jql, onChange: e => setJql(e.target.value) }),
+            React.createElement('input', { placeholder: 'Username', value: username, onChange: e => setUsername(e.target.value) }),
+            React.createElement('input', { placeholder: 'API Token', type: 'password', value: apiToken, onChange: e => setApiToken(e.target.value) }),
+            React.createElement('button', { onClick: fetchData }, 'Fetch')
+          ),
+          React.createElement('table', { border: 1, cellPadding: 5 },
+            React.createElement('thead', null,
+              React.createElement('tr', null,
+                React.createElement('th', null, 'Story'),
+                React.createElement('th', null, 'Count')
+              )
+            ),
+            React.createElement('tbody', null,
+              rows.map(({ story, count }) =>
+                React.createElement('tr', { key: story },
+                  React.createElement('td', null, story),
+                  React.createElement('td', null, count)
+                )
+              )
+            )
+          ),
+          React.createElement(ResponsiveContainer, { width: '100%', height: 300 },
+            React.createElement(BarChart, { data: rows },
+              React.createElement(CartesianGrid, { strokeDasharray: '3 3' }),
+              React.createElement(XAxis, { dataKey: 'story' }),
+              React.createElement(YAxis, null),
+              React.createElement(Tooltip, null),
+              React.createElement(Bar, { dataKey: 'count', fill: '#8884d8' })
+            )
+          )
+        )
+      );
+    }
+
+    ReactDOM.render(React.createElement(App), document.getElementById('root'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This pull request includes the implementation of a Python program to find the number of Jira tickets broken by stories. It also includes unit tests for the Python code, an API to expose the functionality, and a React UI with tables and graphs. Note that no unit tests are required for the React UI.