### PR TITLE
Add Jira Ticket Analysis with API and React UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,40 @@ Run tests with pytest:
 ```bash
 pytest
 ```
+
+## Jira Tickets by Story API and UI
+
+### Configuration
+
+The Jira integration requires the following environment variables:
+
+```bash
+export JIRA_SERVER="https://your-jira-instance"
+export JIRA_USERNAME="your-username"
+export JIRA_API_TOKEN="your-api-token"
+export JIRA_PROJECT_KEY="PROJECTKEY"
+```
+
+### Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### Run the API server
+
+```bash
+uvicorn main:app --reload
+```
+
+### Access the API
+
+The endpoint to fetch ticket counts by story is:
+
+```
+GET /jira/tickets_by_story
+```
+
+### UI
+
+Once the server is running, open your browser to `http://127.0.0.1:8000/` to view the React-based UI showing a table and bar chart of ticket counts by story.

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,2 @@
+# api package
+__all__ = ['jira']

--- a/api/jira.py
+++ b/api/jira.py
@@ -1,0 +1,21 @@
+# api/jira.py
+#
+# FastAPI router exposing JIRA ticket statistics.
+from fastapi import APIRouter, HTTPException
+from jira_client import JiraClient
+
+router = APIRouter()
+
+@router.get("/tickets_by_story")
+def tickets_by_story():
+    """
+    Endpoint to get number of JIRA tickets broken down by parent story.
+    Returns a JSON mapping story keys to their sub-task ticket counts.
+    """
+    try:
+        client = JiraClient()
+        counts = client.get_ticket_counts_by_story()
+        return counts
+    except Exception as exc:
+        # Return 500 with error detail on failure
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,64 @@
+const { useState, useEffect } = React;
+const {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} = Recharts;
+
+function App() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    axios.get('/jira/tickets_by_story')
+      .then(response => {
+        const items = response.data;
+        const formatted = Object.entries(items).map(([story, count]) => ({ story, count }));
+        setData(formatted);
+      })
+      .catch(error => console.error('Error fetching data:', error));
+  }, []);
+
+  return (
+    React.createElement('div', { style: { padding: '20px' } },
+      React.createElement('h1', null, 'Jira Tickets by Story'),
+      React.createElement('table', null,
+        React.createElement('thead', null,
+          React.createElement('tr', null,
+            React.createElement('th', null, 'Story'),
+            React.createElement('th', null, 'Ticket Count')
+          )
+        ),
+        React.createElement('tbody', null,
+          data.map(item => (
+            React.createElement('tr', { key: item.story },
+              React.createElement('td', null, item.story),
+              React.createElement('td', null, item.count)
+            )
+          ))
+        )
+      ),
+      React.createElement('div', { style: { width: '100%', height: 400, marginTop: 50 } },
+        React.createElement(ResponsiveContainer, null,
+          React.createElement(BarChart, { data },
+            React.createElement(CartesianGrid, { strokeDasharray: '3 3' }),
+            React.createElement(XAxis, { dataKey: 'story' }),
+            React.createElement(YAxis, null),
+            React.createElement(Tooltip, null),
+            React.createElement(Legend, null),
+            React.createElement(Bar, { dataKey: 'count', fill: '#8884d8' })
+          )
+        )
+      )
+    )
+  );
+}
+
+ReactDOM.render(
+  React.createElement(App),
+  document.getElementById('root')
+);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Jira Tickets by Story</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/axios/dist/axios.min.js" crossorigin></script>
+    <script src="https://unpkg.com/recharts/umd/Recharts.min.js" crossorigin></script>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 20px; }
+      table { border-collapse: collapse; width: 100%; margin-bottom: 40px; }
+      th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+      th { background: #f4f4f4; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/jira_client.py
+++ b/jira_client.py
@@ -1,0 +1,51 @@
+# jira_client.py
+#
+# Provides a JiraClient to fetch and aggregate JIRA tickets broken down by parent story.
+import os
+try:
+    from jira import JIRA
+except ImportError:
+    JIRA = None
+
+
+class JiraClient:
+    """
+    JiraClient wraps interactions with the JIRA API.
+    It fetches sub-task issues for a project and returns counts grouped by parent story.
+    """
+    def __init__(self, server=None, username=None, token=None, project_key=None):
+        self.server = server or os.getenv("JIRA_SERVER")
+        self.username = username or os.getenv("JIRA_USERNAME")
+        self.token = token or os.getenv("JIRA_API_TOKEN")
+        self.project_key = project_key or os.getenv("JIRA_PROJECT_KEY")
+        if not all([self.server, self.username, self.token, self.project_key]):
+            raise ValueError(
+                "JIRA_SERVER, JIRA_USERNAME, JIRA_API_TOKEN, and JIRA_PROJECT_KEY must be set"
+            )
+        # Verify jira library availability
+        if JIRA is None:
+            raise ValueError("jira library is required; install with 'pip install jira'")
+        # Initialize JIRA client
+        self.client = JIRA(server=self.server, basic_auth=(self.username, self.token))
+
+    def get_ticket_counts_by_story(self):
+        """
+        Returns a dict mapping each story key to the number of sub-task tickets it has.
+        Stories without sub-tasks will appear with a count of zero.
+        """
+        # Fetch all sub-task issues in the project
+        jql_subtasks = f"project = {self.project_key} AND issuetype in subTaskIssueTypes()"
+        subtasks = self.client.search_issues(jql_subtasks, maxResults=False)
+        counts = {}
+        for issue in subtasks:
+            parent = getattr(issue.fields, 'parent', None)
+            if parent:
+                counts[parent.key] = counts.get(parent.key, 0) + 1
+
+        # Ensure all stories appear, even those without sub-tasks
+        jql_stories = f"project = {self.project_key} AND issuetype = Story"
+        stories = self.client.search_issues(jql_stories, maxResults=False)
+        for story in stories:
+            counts.setdefault(story.key, 0)
+
+        return counts

--- a/main.py
+++ b/main.py
@@ -1,7 +1,11 @@
 from fastapi import FastAPI, HTTPException
 from calculator import add, subtract, multiply, divide
+from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
+
+# Mount UI static files (React app)
+app.mount("/", StaticFiles(directory="frontend", html=True), name="frontend")
 
 @app.get("/calculate")
 def calculate(operation: str, x: float, y: float):
@@ -19,3 +23,7 @@ def calculate(operation: str, x: float, y: float):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return {"operation": operation, "x": x, "y": y, "result": result}
+
+# Include JIRA statistics endpoints
+from api.jira import router as jira_router
+app.include_router(jira_router, prefix="/jira")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.95.0
+uvicorn>=0.21.1
+jira>=3.4.0
+pytest>=7.0.0

--- a/tests/test_jira_api.py
+++ b/tests/test_jira_api.py
@@ -1,0 +1,35 @@
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from jira_client import JiraClient
+from main import app
+
+
+@pytest.fixture(autouse=True)
+def env_vars(monkeypatch):
+    monkeypatch.setenv("JIRA_SERVER", "http://example.com")
+    monkeypatch.setenv("JIRA_USERNAME", "user")
+    monkeypatch.setenv("JIRA_API_TOKEN", "token")
+    monkeypatch.setenv("JIRA_PROJECT_KEY", "PROJ")
+
+
+def test_api_tickets_by_story(monkeypatch):
+    # Patch JiraClient.get_ticket_counts_by_story to return predictable data
+    expected = {'STORY-1': 5, 'STORY-2': 3}
+    monkeypatch.setattr(JiraClient, 'get_ticket_counts_by_story', lambda self: expected)
+
+    client = TestClient(app)
+    response = client.get('/jira/tickets_by_story')
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+def test_api_error_handling(monkeypatch):
+    # Simulate an error in JiraClient initialization
+    monkeypatch.setenv("JIRA_SERVER", "")
+    client = TestClient(app)
+    response = client.get('/jira/tickets_by_story')
+    assert response.status_code == 500
+    assert 'detail' in response.json()

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -1,0 +1,71 @@
+import os
+import pytest
+
+from jira_client import JiraClient
+
+
+class DummyIssue:
+    def __init__(self, key, parent_key=None):
+        self.key = key
+        class F:
+            pass
+
+        self.fields = F()
+        if parent_key:
+            class Parent:
+                pass
+
+            self.fields.parent = Parent()
+            self.fields.parent.key = parent_key
+        else:
+            self.fields.parent = None
+
+
+class DummyJIRA:
+    def __init__(self, issues):
+        self._issues = issues
+
+    def search_issues(self, jql, maxResults=False):
+        if 'issuetype in subTaskIssueTypes()' in jql:
+            return self._issues['subtasks']
+        if 'issuetype = Story' in jql:
+            return self._issues['stories']
+        return []
+
+
+@pytest.fixture(autouse=True)
+def env_vars(monkeypatch):
+    monkeypatch.setenv("JIRA_SERVER", "http://example.com")
+    monkeypatch.setenv("JIRA_USERNAME", "user")
+    monkeypatch.setenv("JIRA_API_TOKEN", "token")
+    monkeypatch.setenv("JIRA_PROJECT_KEY", "PROJ")
+
+
+@pytest.fixture(autouse=True)
+def patch_jira(monkeypatch):
+    dummy_data = {
+        'subtasks': [
+            DummyIssue('TASK-1', 'STORY-1'),
+            DummyIssue('TASK-2', 'STORY-1'),
+            DummyIssue('TASK-3', 'STORY-2'),
+        ],
+        'stories': [
+            DummyIssue('STORY-1'),
+            DummyIssue('STORY-2'),
+            DummyIssue('STORY-3'),
+        ],
+    }
+    monkeypatch.setattr(
+        'jira_client.JIRA',
+        lambda server, basic_auth: DummyJIRA(dummy_data)
+    )
+
+
+def test_get_ticket_counts_by_story():
+    client = JiraClient()
+    counts = client.get_ticket_counts_by_story()
+    assert counts == {
+        'STORY-1': 2,
+        'STORY-2': 1,
+        'STORY-3': 0,
+    }


### PR DESCRIPTION
This pull request includes a Python program to find the number of Jira tickets broken by stories, along with unit tests. The program is exposed as an API in a standard way. Additionally, a React UI with tables and graphs is generated, which does not require unit tests.