### PR TITLE
Add Jira Ticket Analysis with API and React UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ demorepo
 
 ## API
 
-Install dependencies:
+Install Python dependencies:
 
 ```bash
-pip install fastapi uvicorn
+pip install -r requirements.txt
 ```
 
 Start the API server:
@@ -40,4 +40,41 @@ Run tests with pytest:
 
 ```bash
 pytest
+```
+
+## Ticket Statistics API
+
+Count JIRA tickets broken down by story via a JSON API.
+
+### Endpoint
+
+```http
+POST /count_by_story
+Content-Type: application/json
+
+{
+  "tickets": [
+    { "id": "T1", "story": "Story A" },
+    { "id": "T2", "story": "Story B" },
+    { "id": "T3", "story": "Story A" }
+  ]
+}
+```
+
+Example successful response:
+
+```json
+{ "counts": { "Story A": 2, "Story B": 1 } }
+```
+
+## Frontend UI
+
+A React application is provided in the `frontend/` directory. It displays the ticket counts in a table and bar chart.
+
+To run the UI:
+
+```bash
+cd frontend
+npm install
+npm start
 ```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "jira-ui",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-scripts": "5.0.0",
+    "chart.js": "^4.3.0",
+    "react-chartjs-2": "^5.2.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>JIRA Ticket Stats</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { Bar } from 'react-chartjs-2';
+import 'chart.js/auto';
+
+function App() {
+  const [counts, setCounts] = useState({});
+
+  useEffect(() => {
+    fetch('/count_by_story', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tickets: [
+          { id: 'T1', story: 'Story A' },
+          { id: 'T2', story: 'Story B' },
+          { id: 'T3', story: 'Story A' },
+        ],
+      }),
+    })
+      .then((res) => res.json())
+      .then((data) => setCounts(data.counts))
+      .catch((err) => console.error(err));
+  }, []);
+
+  const stories = Object.keys(counts);
+  const values = stories.map((s) => counts[s]);
+
+  const data = {
+    labels: stories,
+    datasets: [
+      {
+        label: 'Ticket Count',
+        data: values,
+        backgroundColor: 'rgba(75, 192, 192, 0.6)',
+      },
+    ],
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>JIRA Tickets Broken Down by Story</h1>
+      <table border="1" cellPadding="5">
+        <thead>
+          <tr>
+            <th>Story</th>
+            <th>Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {stories.map((story) => (
+            <tr key={story}>
+              <td>{story}</td>
+              <td>{counts[story]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div style={{ maxWidth: '600px', marginTop: '40px' }}>
+        <Bar data={data} />
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);

--- a/jira_stats/__init__.py
+++ b/jira_stats/__init__.py
@@ -1,0 +1,1 @@
+"""JIRA statistics package."""

--- a/jira_stats/api.py
+++ b/jira_stats/api.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, HTTPException
+
+from jira_stats.core import count_tickets_by_story
+
+router = APIRouter()
+
+
+@router.post("/count_by_story")
+async def count_by_story_endpoint(payload: dict):
+    """
+    Count tickets by story from JSON payload.
+
+    Request body should be:
+    {
+        "tickets": [ {"id": "...", "story": "Story A"}, ... ]
+    }
+    """
+    tickets = payload.get("tickets")
+    if tickets is None or not isinstance(tickets, list):
+        raise HTTPException(status_code=400, detail="Invalid payload: 'tickets' list required")
+    return {"counts": count_tickets_by_story(tickets)}

--- a/jira_stats/core.py
+++ b/jira_stats/core.py
@@ -1,0 +1,14 @@
+def count_tickets_by_story(tickets):
+    """
+    Count the number of tickets grouped by their story.
+
+    :param tickets: List of tickets, each a dict with 'story' key.
+    :return: dict mapping story to count.
+    """
+    counts = {}
+    for ticket in tickets:
+        story = ticket.get('story')
+        if story is None:
+            continue
+        counts[story] = counts.get(story, 0) + 1
+    return counts

--- a/main.py
+++ b/main.py
@@ -3,6 +3,10 @@ from calculator import add, subtract, multiply, divide
 
 app = FastAPI()
 
+from jira_stats.api import router as jira_router
+
+app.include_router(jira_router)
+
 @app.get("/calculate")
 def calculate(operation: str, x: float, y: float):
     operations = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/tests/test_api_count_by_story.py
+++ b/tests/test_api_count_by_story.py
@@ -1,0 +1,28 @@
+import pytest
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_count_by_story_success():
+    payload = {
+        "tickets": [
+            {"id": "T1", "story": "Story A"},
+            {"id": "T2", "story": "Story B"},
+            {"id": "T3", "story": "Story A"},
+        ]
+    }
+    response = client.post("/count_by_story", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"counts": {"Story A": 2, "Story B": 1}}
+
+
+@pytest.mark.parametrize("payload", [ {}, {"tickets": "not a list"}, {"tickets": None} ])
+def test_count_by_story_invalid_payload(payload):
+    response = client.post("/count_by_story", json=payload)
+    assert response.status_code == 400
+    assert "Invalid payload" in response.json().get("detail", "")

--- a/tests/test_jira_stats_core.py
+++ b/tests/test_jira_stats_core.py
@@ -1,0 +1,39 @@
+import pytest
+
+from jira_stats.core import count_tickets_by_story
+
+
+def test_empty_list():
+    assert count_tickets_by_story([]) == {}
+
+
+def test_single_ticket():
+    tickets = [{"id": "T1", "story": "Story A"}]
+    assert count_tickets_by_story(tickets) == {"Story A": 1}
+
+
+def test_multiple_tickets_same_story():
+    tickets = [
+        {"id": "T1", "story": "Story A"},
+        {"id": "T2", "story": "Story A"},
+    ]
+    assert count_tickets_by_story(tickets) == {"Story A": 2}
+
+
+def test_multiple_stories():
+    tickets = [
+        {"id": "T1", "story": "Story A"},
+        {"id": "T2", "story": "Story B"},
+        {"id": "T3", "story": "Story A"},
+    ]
+    assert count_tickets_by_story(tickets) == {"Story A": 2, "Story B": 1}
+
+
+def test_ticket_without_story():
+    tickets = [
+        {"id": "T1", "story": "Story A"},
+        {"id": "T2"},
+        {"id": "T3", "story": None},
+    ]
+    # Tickets without a valid 'story' field are ignored
+    assert count_tickets_by_story(tickets) == {"Story A": 1}


### PR DESCRIPTION
This pull request includes a Python program to find the number of Jira tickets broken by stories. It also includes unit tests, an API to expose the functionality, and a React UI with tables and graphs. Note: No unit tests are required for the React UI.